### PR TITLE
JPMS Strictly Named Modules

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -18,21 +18,6 @@ of Jackson: application code should only rely on `jackson-bom`
         (but some core components require override)
       -->
     <jdk.module.name>${packageVersion.package}</jdk.module.name>
-
-      <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
-          and new language features (diamond pattern) may be used.
-          JDK classes are still loaded dynamically since there isn't much downside
-          (small number of types); this allows use on JDK 6 platforms still (including
-          Android)
-       -->
-      <!-- TODO Remove JDK 11 Settings -->
-      <javac.src.version>1.11</javac.src.version>
-      <javac.target.version>1.11</javac.target.version>
-
-      <jdk.version>1.11</jdk.version>
-      <maven.compiler.source>1.11</maven.compiler.source>
-      <maven.compiler.target>1.11</maven.compiler.target>
-      <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <dependencies>
@@ -55,11 +40,9 @@ of Jackson: application code should only rely on `jackson-bom`
 
     </dependencyManagement>
 
-
     <build>
     <pluginManagement>
       <plugins>
-
         <!-- Verify existence of certain settings
           -->
         <plugin>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion> 
+    <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.fasterxml.jackson</groupId>
     <artifactId>jackson-bom</artifactId>
@@ -19,6 +19,20 @@ of Jackson: application code should only rely on `jackson-bom`
       -->
     <jdk.module.name>${packageVersion.package}</jdk.module.name>
 
+      <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
+          and new language features (diamond pattern) may be used.
+          JDK classes are still loaded dynamically since there isn't much downside
+          (small number of types); this allows use on JDK 6 platforms still (including
+          Android)
+       -->
+      <!-- TODO Remove JDK 11 Settings -->
+      <javac.src.version>1.11</javac.src.version>
+      <javac.target.version>1.11</javac.target.version>
+
+      <jdk.version>1.11</jdk.version>
+      <maven.compiler.source>1.11</maven.compiler.source>
+      <maven.compiler.target>1.11</maven.compiler.target>
+      <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <dependencies>
@@ -29,7 +43,20 @@ of Jackson: application code should only rely on `jackson-bom`
     </dependency>
   </dependencies>
 
-  <build>
+    <dependencyManagement>
+        <dependencies>
+            <!-- JPMS Libraries-->
+            <dependency>
+                <groupId>javax.activation</groupId>
+                <artifactId>javax.activation-api</artifactId>
+                <version>${javax.activation.version}</version>
+            </dependency>
+        </dependencies>
+
+    </dependencyManagement>
+
+
+    <build>
     <pluginManagement>
       <plugins>
 

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -67,6 +67,7 @@ of Jackson: application code should only rely on `jackson-bom`
                   <banSnapshots>true</banSnapshots>
                   <phases>clean,deploy,site</phases>
                   <message>[ERROR] Best Practice is to always define plugin versions!</message>
+                    <unCheckedPluginList>org.moditect:moditect-maven-plugin</unCheckedPluginList>
                 </requirePluginVersions>
 	      </rules>
 	      </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <!-- 07-Sep-2017, tatu: ... although in special case of 2.9.1 that would
        add Java 9 Automatic Module Name so need to consider
       -->
-    <jackson.version.annotations>2.9.0</jackson.version.annotations>
+      <jackson.version.annotations>${jackson.version}</jackson.version.annotations>
     <jackson.version.core>${jackson.version}</jackson.version.core>
     <jackson.version.databind>${jackson.version}</jackson.version.databind>
     <jackson.version.dataformat>${jackson.version}</jackson.version.dataformat>
@@ -47,6 +47,8 @@
     <jackson.version.module>${jackson.version}</jackson.version.module>
     <jackson.version.module.kotlin>${jackson.version.module}</jackson.version.module.kotlin>
     <jackson.version.module.scala>${jackson.version.module}</jackson.version.module.scala>
+      <!-- JPMS Library Updates-->
+      <javax.activation.version>1.2.0</javax.activation.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.fasterxml.jackson</groupId>
     <artifactId>jackson-parent</artifactId>
     <!-- note: does NOT change for every version of bom -->
-    <version>2.9.1.1</version>
+    <version>2.9.1.2</version>
   </parent>
 
   <artifactId>jackson-bom</artifactId>


### PR DESCRIPTION
* JAXB Bump to 2.3.0
* Guice Minimum set to 4.2.2 for JPMS
* JSON Setter - couldn't find merge annotation method on branch 2.9
* JPMS Strictly Named Modules with Hard Exports ONLY

JPMS Considerations
===================
For Private/Protected Field Scanning, The required package should open to com.fasterxml.jackson.databind.
This is how it currently works with automatic module naming, but it is now strictly enforced