### PR TITLE
Add platform dependency to Jackson BOM for Gradle consumers

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -151,6 +151,27 @@ of Jackson: application code should only rely on `jackson-bom`
           </executions>
 	</plugin>
 
+        <plugin>
+          <groupId>de.jjohannes</groupId>
+          <artifactId>gradle-module-metadata-maven-plugin</artifactId>
+          <version>0.1.0</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>gmm</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <platformDependencies>
+              <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${project.version}</version>
+              </dependency>
+            </platformDependencies>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
See this [mailing list discussion](https://groups.google.com/d/msg/jackson-user/OTwpIl6chUY/g7s9ov5dFgAJ) and [this blog post](https://blog.gradle.org/alignment-with-gradle-module-metadata).


This configures the 'gradle-module-metadata-maven-plugin' to write
and publish a Gradle Module Metadata file that contains a platform
dependency to the Jackson BOM.

All projects that have jackson-base as parent should then activate
this plugin an the use of Gradle Module Metadata by adding:

```
  <!-- do_not_remove: published-with-gradle-metadata -->
```

right below the `<project>` opening tag

As well as:

```
  <plugin>
    <groupId>de.jjohannes</groupId>
    <artifactId>gradle-module-metadata-maven-plugin</artifactId>
  </plugin>
```

to the `<plugins>` block.