### PR TITLE
Add BOM entry for 'jackson-jr-annotation-support'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,11 @@ of Jackson components maintained by FasterXML.com
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jr</groupId>
+        <artifactId>jackson-jr-annotation-support</artifactId>
+        <version>${jackson.version.jacksonjr}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.jr</groupId>
         <artifactId>jackson-jr-objects</artifactId>
         <version>${jackson.version.jacksonjr}</version>
       </dependency>


### PR DESCRIPTION
The BOM was not update when _jackson-jr-annotation-support_ was introduced.