### PR TITLE
Add GitHub workflow to replace Travis CI

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository/>
+  <interactiveMode/>
+  <usePluginRegistry/>
+  <offline/>
+  <pluginGroups/>
+  <servers>
+    <server>
+      <id>sonatype-nexus-snapshots</id>
+      <username>${env.CI_DEPLOY_USERNAME}</username>
+      <password>${env.CI_DEPLOY_PASSWORD}</password>
+    </server>
+  </servers>
+  <mirrors/>
+  <proxies/>
+  <profiles/>
+  <activeProfiles/>
+</settings>
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,39 @@
+name: Main
+on:
+  push:
+    branches:
+    - master
+    - "3.0"
+  pull_request:
+    branches:
+    - master
+    - "3.0"
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        java_version: ['8', '11']
+        os: ['ubuntu-20.04']
+    env:
+      JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK
+      uses: joschi/setup-jdk@v2.3.0
+      with:
+        java-version: ${{ matrix.java_version }}
+    - uses: actions/cache@v2.1.3
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    - name: Build
+      run: mvn -V -B -ff -ntp -s verify
+    - name: Deploy snapshot
+      env:
+        CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
+        CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
+      run: mvn -V -B -ff -ntp -s .github/settings.xml deploy


### PR DESCRIPTION
Replace the Travis CI build job with an equivalent GitHub workflow.

**TODO:** Add `CI_DEPLOY_USERNAME` and `CI_DEPLOY_PASSWORD` encrypted secrets to repository:
https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets