### PR TITLE
Add missing scala 2.13 module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,6 +303,11 @@
         <artifactId>jackson-module-scala_2.12</artifactId>
         <version>${jackson.version.module.scala}</version>
       </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-scala_2.13</artifactId>
+        <version>${jackson.version.module.scala}</version>
+      </dependency>
 
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
We were using this 2.9.10 bom with scala 2.13.4 and Kafka 2.7.0
which also has a dependency on jackson.

This would lead to a newer dependcy for jackson-module-scala.