### PR TITLE
Use oss-parent 42

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
       -->
     <groupId>com.fasterxml</groupId>
     <artifactId>oss-parent</artifactId>
-    <version>41</version>
+    <version>42</version>
   </parent>
 
   <groupId>com.fasterxml.jackson</groupId>


### PR DESCRIPTION
jackson-module-kotlin uses jackson-base from this repo (in re: https://github.com/FasterXML/oss-parent/pull/28)