### PR TITLE
add jackson-module-scala_3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -396,6 +396,11 @@ of Jackson components maintained by FasterXML.com
         <artifactId>jackson-module-scala_2.13</artifactId>
         <version>${jackson.version.module.scala}</version>
       </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-scala_3</artifactId>
+        <version>${jackson.version.module.scala}</version>
+      </dependency>
 
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
jackson v2.13.0 was first release to support scala 3