### PR TITLE
Fix #46: move module info to under META-INF/versions/9

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -160,7 +160,7 @@ of Jackson: application code should only rely on `jackson-bom`
               under "META-INF/versions/11" (instead of root, /); helps pre-Java9
               libraries, frameworks, as well as avoids warnings by tooling
             -->
-	  <!-- 27-Jan-2022, tatu: as per [databind#3380] etc, really need to use
+          <!-- 27-Jan-2022, tatu: as per [databind#3380] etc, really need to use
                "META-INF/versions/9" for tooling compatibility
             -->
           <configuration>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -160,8 +160,11 @@ of Jackson: application code should only rely on `jackson-bom`
               under "META-INF/versions/11" (instead of root, /); helps pre-Java9
               libraries, frameworks, as well as avoids warnings by tooling
             -->
+	  <!-- 27-Jan-2022, tatu: as per [databind#3380] etc, really need to use
+               "META-INF/versions/9" for tooling compatibility
+            -->
           <configuration>
-            <jvmVersion>11</jvmVersion>
+            <jvmVersion>9</jvmVersion>
           </configuration>
 	</plugin>
 

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -9,6 +9,10 @@ Jackson components (core, modules)
 === Releases (note: only includes patches with actual changes)
 ------------------------------------------------------------------------
 
+2.13.2 (not yet changed)
+
+#46: `module-info.java` is in `META-INF/versions/11` instead of `META-INF/versions/9`
+
 2.13.1 (19-Dec-2021)
 
 No changes since 2.13.0


### PR DESCRIPTION
As per issue #46 title: move `module-info.class` to under JDK-9 location from JDK-11.
