### PR TITLE
jackson.version should be 2.14.0-rc1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@ of Jackson components maintained by FasterXML.com
   </scm>
 
   <properties>
-    <jackson.version>2.14.0-SNAPSHOT</jackson.version>
+    <jackson.version>2.14.0-rc1-SNAPSHOT</jackson.version>
 
     <!-- 25-Sep-2019, tatu: With Jackson 2.x we will release full patch-level versions
            of annotations BUT they are all identical, content-wise.


### PR DESCRIPTION
the current value of 2.14.0-SNAPSHOT means that I can't use the latest jackson-core changes in jackson-databind 