### PR TITLE
Add 'org.gradlex:gradle-module-metadata-maven-plugin:1.0'

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -193,6 +193,29 @@ of Jackson: application code should only rely on `jackson-bom`
 	</plugin>
 
         <plugin>
+          <groupId>org.gradlex</groupId>
+          <artifactId>gradle-module-metadata-maven-plugin</artifactId>
+          <version>1.0</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>gmm</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <platformDependencies>
+              <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson-bom.version}</version>
+              </dependency>
+            </platformDependencies>
+          </configuration>
+        </plugin>
+
+        <!-- TODO jjohannes: remove the below once it is no longer used by child poms -->
+        <plugin>
           <groupId>de.jjohannes</groupId>
           <artifactId>gradle-module-metadata-maven-plugin</artifactId>
           <version>0.4.0</version>


### PR DESCRIPTION
@cowtowncoder We moved the `gradle-module-metadata-maven-plugin` to https://gradlex.org. For now, I am still the main maintainer, but on the long run this should ensure support not only from me. There is now an official `1.0` release. It has a improvement (https://github.com/gradlex-org/gradle-module-metadata-maven-plugin/pull/26) that we may use to get rid of the  `find-and-replace-maven-plugin` we needed to add in some places to make it work together with the `shade` plugin.

My suggestion is:
1. Add the new plugin to the `<pluginManagement>` of `jackson-base` with the same configuration as the old one (this PR)
2. When we have a new SNAPSHOT with the change in `jackson-base`, do PRs to all repos that activate the plugin to update to the new version **AND** fix the ordering to address. I can do this within this week.
3. Once all repos are updated, we can remove the old plugin from `jackson-base`.

After that, all repos will use `1.0` and https://github.com/FasterXML/jackson-databind/issues/4985 will be fixed everywhere.

Let me know what you think.