### PR TITLE
Bump org.gradlex:gradle-module-metadata-maven-plugin to 1.0.1

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -195,7 +195,7 @@ of Jackson: application code should only rely on `jackson-bom`
         <plugin>
           <groupId>org.gradlex</groupId>
           <artifactId>gradle-module-metadata-maven-plugin</artifactId>
-          <version>1.0</version>
+          <version>1.0.1</version>
           <executions>
             <execution>
               <goals>


### PR DESCRIPTION
Fixes the issue with checksums described here: https://github.com/FasterXML/jackson-bom/pull/85#issuecomment-2692161566
See: https://github.com/gradlex-org/java-module-dependencies/pull/33