### PR TITLE
Bump org.gradlex:gradle-module-metadata-maven-plugin to 1.2

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -213,7 +213,7 @@ of Jackson: application code should only rely on `jackson-bom`
         <plugin>
           <groupId>org.gradlex</groupId>
           <artifactId>gradle-module-metadata-maven-plugin</artifactId>
-          <version>1.0.1</version>
+          <version>1.2</version>
           <executions>
             <execution>
               <goals>


### PR DESCRIPTION
With this users won't run into the following specific Gradle issue with future Jackson releases:
https://github.com/gradlex-org/gradle-module-metadata-maven-plugin/issues/45