### PR TITLE
Update Jackson BOM version to 2.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ or imported in `<dependencyManagement>` section)
     <dependency>
       <groupId>com.fasterxml.jackson</groupId>
       <artifactId>jackson-bom</artifactId>
-      <version>2.16.1</version>
+      <version>2.20.0</version>
       <scope>import</scope>
       <type>pom</type>
     </dependency>   

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There are two ways to use the BOM pom: either as parent pom:
   <parent>
     <groupId>com.fasterxml.jackson</groupId>
     <artifactId>jackson-bom</artifactId>
-    <version>2.16.1</version>
+    <version>2.20.0</version>
   </parent>
 ```
 


### PR DESCRIPTION
people are complaining about jackson-annotations and one answer is that they can use jackson-bom - so getting the version number up to date would be great