### PR TITLE
Fix Artifact Maven Central badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ set of compatible versions to use by specifying a single version number.
 | Type | Status |
 | ---- | ------ |
 | Build (CI) | [![Build (github)](https://github.com/FasterXML/jackson-bom/actions/workflows/main.yml/badge.svg)](https://github.com/FasterXML/jackson-bom/actions/workflows/main.yml) |
-| Artifact | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson/jackson-bom/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson/jackson-bom) |
+| Artifact | [![Maven Central](https://img.shields.io/maven-central/v/tools.jackson/jackson-bom?style=flat&color=dark-green&label=Maven%20Central)](https://central.sonatype.com/artifact/tools.jackson/jackson-bom) |
 | OSS Sponsorship | [![Tidelift](https://tidelift.com/badges/package/maven/com.fasterxml.jackson:jackson-bom)](https://tidelift.com/subscription/pkg/maven-com-fasterxml-jackson-jackson-bom?utm_source=maven-com-fasterxml-jackson-jackson-bom&utm_medium=referral&utm_campaign=readme) |
 
 ## Usage


### PR DESCRIPTION
The Maven Central badge in the README was pointing to a broken `maven-badges.herokuapp.com` URL.

This updates the badge to use Shields.io and links it to the Sonatype Central page for `tools.jackson:jackson-bom`, which is the artifact used for Jackson 3.x.

<img width="598" height="545" alt="Screenshot 2026-07-02 at 14 31 09" src="https://github.com/user-attachments/assets/ca85e37d-1e20-45b2-b4a8-c869f79a0be7" />
